### PR TITLE
Add QGaussRadau quadrature formula + tests

### DIFF
--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -47,6 +47,58 @@ public:
   QGauss(const unsigned int n);
 };
 
+/**
+ * The Gauss-Radau family of quadrature rules for numerical integration.
+ *
+ * This modification of the Gauss quadrature uses one of the two interval end
+ * points as well. Being exact for polynomials of degree <i>2n-2</i>, this
+ * formula is suboptimal by one degrees.
+ *
+ * The quadrature points are the left interval end point plus the roots of the
+ * polynomial <i>(P<sub>n-1</sub>(x)+P<sub>n</sub>(x))/(1+x)</i>
+ * where <i>P<sub>n-1</sub></i> and <i>P<sub>n</sub></i> are Legendre
+ * polynomials. The quadrature weights are <i>2/n<sup>2</sup></i> and
+ * <i>(1-x<sub>i</sub>)/(n<sup>2</sup>(P<sub>n-1</sub>(x<sub>i</sub>))<sup>2</sup>)</i>.
+ *
+ * For the right Gauss-Radau formula the quadrature points are the points
+ * <i>1-x<sub>i</sub></i>, where <i>x<sub>i</sub></i> are the quadrature points
+ * of the left Gauss-Radau formula.
+ *
+ * @note This implementation only features the known exact roots up to
+ * n = 3 quadrature points.
+ *
+ * @sa https://mathworld.wolfram.com/RadauQuadrature.html @sa
+ */
+template <int dim>
+class QGaussRadau : public Quadrature<dim>
+{
+public:
+  /* EndPoint is used to specify which of the two endpoints of the unit interval
+   * is used also as quadrature point
+   */
+  enum EndPoint
+  {
+    /**
+     * Left end point.
+     */
+    left,
+    /**
+     * Right end point.
+     */
+    right
+  };
+  QGaussRadau(const unsigned int n, EndPoint ep = QGaussRadau::left);
+
+  /**
+   * Move constructor. We cannot rely on the move constructor for `Quadrature`,
+   * since it does not know about the additional member `ep` of this class.
+   */
+  QGaussRadau(QGaussRadau<dim> &&) noexcept = default;
+
+private:
+  const EndPoint ep;
+};
+
 
 /**
  * The Gauss-Lobatto family of quadrature rules for numerical integration.
@@ -942,6 +994,8 @@ public:
 #ifndef DOXYGEN
 template <>
 QGauss<1>::QGauss(const unsigned int n);
+template <>
+QGaussRadau<1>::QGaussRadau(const unsigned int n, QGaussRadau<1>::EndPoint ep);
 template <>
 QGaussLobatto<1>::QGaussLobatto(const unsigned int n);
 

--- a/tests/base/quadrature_test.cc
+++ b/tests/base/quadrature_test.cc
@@ -46,6 +46,12 @@ fill_vector(std::vector<Quadrature<dim> *> &quadratures)
     {
       quadratures.push_back(new QGaussLobatto<dim>(i));
     }
+  for (unsigned int i = 1; i < 4; ++i)
+    {
+      quadratures.push_back(new QGaussRadau<dim>(i));
+      quadratures.push_back(
+        new QGaussRadau<dim>(i, QGaussRadau<dim>::EndPoint::right));
+    }
 }
 
 template <int dim>

--- a/tests/base/quadrature_test.output
+++ b/tests/base/quadrature_test.output
@@ -20,6 +20,17 @@ DEAL:1d::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:1d::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:1d::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:1d::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:1d::Quadrature no.21 is exact for polynomials of degree 0
+DEAL:1d::Quadrature no.22 is exact for polynomials of degree 0
+DEAL:1d::Quadrature no.23 is exact for polynomials of degree 2
+DEAL:1d::Quadrature no.24 is exact for polynomials of degree 2
+DEAL:1d::1.00000
+DEAL:1d::0.333333
+DEAL:1d::Quadrature no.25 is exact for polynomials of degree 4
+DEAL:1d::Quadrature no.26 is exact for polynomials of degree 4
+DEAL:1d::1.00000
+DEAL:1d::0.644949
+DEAL:1d::0.155051
 DEAL:2d::Quadrature no.0 is exact for polynomials of degree 1
 DEAL:2d::Quadrature no.1 is exact for polynomials of degree 1
 DEAL:2d::Quadrature no.2 is exact for polynomials of degree 3
@@ -41,6 +52,12 @@ DEAL:2d::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:2d::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:2d::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:2d::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:2d::Quadrature no.21 is exact for polynomials of degree 0
+DEAL:2d::Quadrature no.22 is exact for polynomials of degree 0
+DEAL:2d::Quadrature no.23 is exact for polynomials of degree 2
+DEAL:2d::Quadrature no.24 is exact for polynomials of degree 2
+DEAL:2d::Quadrature no.25 is exact for polynomials of degree 4
+DEAL:2d::Quadrature no.26 is exact for polynomials of degree 4
 DEAL:2d:faces::Quadrature no.0 is exact for polynomials of degree 1
 DEAL:2d:faces::Quadrature no.1 is exact for polynomials of degree 1
 DEAL:2d:faces::Quadrature no.2 is exact for polynomials of degree 3
@@ -62,6 +79,12 @@ DEAL:2d:faces::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:2d:faces::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:2d:faces::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:2d:faces::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:2d:faces::Quadrature no.21 is exact for polynomials of degree 0
+DEAL:2d:faces::Quadrature no.22 is exact for polynomials of degree 0
+DEAL:2d:faces::Quadrature no.23 is exact for polynomials of degree 2
+DEAL:2d:faces::Quadrature no.24 is exact for polynomials of degree 2
+DEAL:2d:faces::Quadrature no.25 is exact for polynomials of degree 4
+DEAL:2d:faces::Quadrature no.26 is exact for polynomials of degree 4
 DEAL:2d:subfaces::Quadrature no.0 is exact for polynomials of degree 1
 DEAL:2d:subfaces::Quadrature no.1 is exact for polynomials of degree 1
 DEAL:2d:subfaces::Quadrature no.2 is exact for polynomials of degree 3
@@ -83,6 +106,12 @@ DEAL:2d:subfaces::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:2d:subfaces::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:2d:subfaces::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:2d:subfaces::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:2d:subfaces::Quadrature no.21 is exact for polynomials of degree 0
+DEAL:2d:subfaces::Quadrature no.22 is exact for polynomials of degree 0
+DEAL:2d:subfaces::Quadrature no.23 is exact for polynomials of degree 2
+DEAL:2d:subfaces::Quadrature no.24 is exact for polynomials of degree 2
+DEAL:2d:subfaces::Quadrature no.25 is exact for polynomials of degree 4
+DEAL:2d:subfaces::Quadrature no.26 is exact for polynomials of degree 4
 DEAL:3d::Quadrature no.0 is exact for polynomials of degree 1
 DEAL:3d::Quadrature no.1 is exact for polynomials of degree 1
 DEAL:3d::Quadrature no.2 is exact for polynomials of degree 3
@@ -104,6 +133,12 @@ DEAL:3d::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:3d::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:3d::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:3d::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:3d::Quadrature no.21 is exact for polynomials of degree 0
+DEAL:3d::Quadrature no.22 is exact for polynomials of degree 0
+DEAL:3d::Quadrature no.23 is exact for polynomials of degree 2
+DEAL:3d::Quadrature no.24 is exact for polynomials of degree 2
+DEAL:3d::Quadrature no.25 is exact for polynomials of degree 4
+DEAL:3d::Quadrature no.26 is exact for polynomials of degree 4
 DEAL:3d:faces::Quadrature no.0 is exact for polynomials of degree 1
 DEAL:3d:faces::Quadrature no.1 is exact for polynomials of degree 1
 DEAL:3d:faces::Quadrature no.2 is exact for polynomials of degree 3
@@ -125,6 +160,12 @@ DEAL:3d:faces::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:3d:faces::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:3d:faces::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:3d:faces::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:3d:faces::Quadrature no.21 is exact for polynomials of degree 1
+DEAL:3d:faces::Quadrature no.22 is exact for polynomials of degree 1
+DEAL:3d:faces::Quadrature no.23 is exact for polynomials of degree 3
+DEAL:3d:faces::Quadrature no.24 is exact for polynomials of degree 3
+DEAL:3d:faces::Quadrature no.25 is exact for polynomials of degree 5
+DEAL:3d:faces::Quadrature no.26 is exact for polynomials of degree 5
 DEAL:3d:subfaces::Quadrature no.0 is exact for polynomials of degree 1
 DEAL:3d:subfaces::Quadrature no.1 is exact for polynomials of degree 1
 DEAL:3d:subfaces::Quadrature no.2 is exact for polynomials of degree 3
@@ -146,3 +187,9 @@ DEAL:3d:subfaces::Quadrature no.17 is exact for polynomials of degree 5
 DEAL:3d:subfaces::Quadrature no.18 is exact for polynomials of degree 7
 DEAL:3d:subfaces::Quadrature no.19 is exact for polynomials of degree 9
 DEAL:3d:subfaces::Quadrature no.20 is exact for polynomials of degree 11
+DEAL:3d:subfaces::Quadrature no.21 is exact for polynomials of degree 1
+DEAL:3d:subfaces::Quadrature no.22 is exact for polynomials of degree 1
+DEAL:3d:subfaces::Quadrature no.23 is exact for polynomials of degree 3
+DEAL:3d:subfaces::Quadrature no.24 is exact for polynomials of degree 3
+DEAL:3d:subfaces::Quadrature no.25 is exact for polynomials of degree 5
+DEAL:3d:subfaces::Quadrature no.26 is exact for polynomials of degree 5


### PR DESCRIPTION
This adds the Gauss-Radau quadrature formulae up to n=3 points,
as described here: https://mathworld.wolfram.com/RadauQuadrature.html.
The given numerical values for n=4 and n=5 are not accurate enough
and application to the test polynomials 
of quadrature_test.cc were not exact for degrees > 0.

On the 3d faces and subfaces the QF is able to integrate the given 
polynomial in the test suite of one order higher than in all other cases.
This is reflected in the quadrature_test.ouput file for numdiff comparison.